### PR TITLE
Ensure new timm version: `timm>=1.0.3`

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -33,7 +33,7 @@ dependencies:
       - tensorboard
       - fairscale
       - wandb
-      - timm
+      - timm>=1.0.3
       - packaging==23.2
       - ninja==1.11.1.1
       - transformers==4.36.2


### PR DESCRIPTION
`timm=0.9.8` has been reported to result in bugs when creating a tile encoder: #2